### PR TITLE
fix: convert milliseconds to seconds for storing in redis

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -35,7 +35,7 @@ function builder(
       if (!isCacheable(value))
         throw new Error(`"${value}" is not a cacheable value`);
       const t = ttl === undefined ? options?.ttl : ttl;
-      if (t) await redisCache.setex(key, t, getVal(value));
+      if (t) await redisCache.setex(key, t / 1000, getVal(value));
       else await redisCache.set(key, getVal(value));
     },
     async mset(args, ttl) {


### PR DESCRIPTION
The set was not being converted to seconds, so using it from cache-manager and passing in milliseconds would store in redis for a very long time.

The mset seems to have already added this.

