### PR TITLE
fix: Return ttl in msec instead of sec.

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -88,7 +88,7 @@ function builder(
     async del(key) {
       await redisCache.del(key);
     },
-    ttl: async (key) => redisCache.ttl(key),
+    ttl: async (key) => redisCache.pttl(key),
     keys: (pattern = '*') => keys(pattern),
     reset,
     isCacheable,


### PR DESCRIPTION
This is to match behaviour of other cache-manager 5 and the other stores.