### PR TITLE
fix: serialize Date/Bigint/etc properly 

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,8 @@
   },
   "dependencies": {
     "cache-manager": "^5.2.3",
-    "ioredis": "^5.3.2"
+    "ioredis": "^5.3.2",
+    "telejson": "^7.2.0"
   },
   "devDependencies": {
     "@commitlint/cli": "17.7.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,9 @@ dependencies:
   ioredis:
     specifier: ^5.3.2
     version: 5.3.2
+  telejson:
+    specifier: ^7.2.0
+    version: 7.2.0
 
 devDependencies:
   '@commitlint/cli':
@@ -3655,6 +3658,16 @@ packages:
     engines: {node: '>=8'}
     dev: true
 
+  /map-or-similar@1.5.0:
+    resolution: {integrity: sha512-0aF7ZmVon1igznGI4VS30yugpduQW3y3GkcgGJOp7d8x8QrizhigUxjI/m2UojsXXto+jLAH3KSz+xOJTiORjg==}
+    dev: false
+
+  /memoizerific@1.11.3:
+    resolution: {integrity: sha512-/EuHYwAPdLtXwAwSZkh/Gutery6pD2KYd44oQLhAvQp/50mpyduZh8Q7PYHXTCJ+wuXxt7oij2LXyIJOOYFPog==}
+    dependencies:
+      map-or-similar: 1.5.0
+    dev: false
+
   /meow@12.1.1:
     resolution: {integrity: sha512-BhXM0Au22RwUneMPwSCnyhTOizdWoIEPU9sp0Aqa1PnDMR5Wv2FGXYDjuzJEIX+Eo2Rb8xuYe5jrnm5QowQFkw==}
     engines: {node: '>=16.10'}
@@ -4861,6 +4874,12 @@ packages:
     resolution: {integrity: sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==}
     engines: {node: '>= 0.4'}
     dev: true
+
+  /telejson@7.2.0:
+    resolution: {integrity: sha512-1QTEcJkJEhc8OnStBx/ILRu5J2p0GjvWsBx56bmZRqnrkdBMUe+nX92jxV+p3dB4CP6PZCdJMQJwCggkNBMzkQ==}
+    dependencies:
+      memoizerific: 1.11.3
+    dev: false
 
   /test-exclude@6.0.0:
     resolution: {integrity: sha512-cAGWPIyOHU6zlmg88jwm7VRyXnMN7iV68OGAbYDk/Mh/xC/pzVPlQtY6ngoIH/5/tciuhGfvESU8GrHrcxD56w==}

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -143,6 +143,19 @@ describe('mset', () => {
     ]);
   });
 
+  it('should store a Date', async () => {
+    const date = new Date();
+
+    await redisCache.store.mset([
+      ['foo', date],
+      ['foo2', date],
+    ]);
+    await expect(redisCache.store.mget('foo', 'foo2')).resolves.toStrictEqual([
+      date,
+      date,
+    ]);
+  });
+
   it('should not store an invalid value', () =>
     expect(redisCache.store.mset([['foo1', undefined]])).rejects.toBeDefined());
 

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -143,16 +143,17 @@ describe('mset', () => {
     ]);
   });
 
-  it('should store a Date', async () => {
+  it('should store Date and Bigint', async () => {
     const date = new Date();
+    const bigint = BigInt(100);
 
     await redisCache.store.mset([
       ['foo', date],
-      ['foo2', date],
+      ['foo2', bigint],
     ]);
     await expect(redisCache.store.mget('foo', 'foo2')).resolves.toStrictEqual([
       date,
-      date,
+      bigint,
     ]);
   });
 
@@ -167,7 +168,7 @@ describe('mset', () => {
     ]);
     await expect(
       customRedisCache.store.mget('foo3', 'foo4'),
-    ).resolves.toStrictEqual(['undefined', 'undefined']);
+    ).resolves.toStrictEqual([undefined, undefined]);
   });
 
   it('should not store a value disallowed by isCacheable', async () => {


### PR DESCRIPTION
Use https://www.npmjs.com/package/telejson to serialize and deserialize data so that we can retain types.

BREAKING CHANGE:
the data stored in redis has a different format
which is incompatible with previous versions
of the library

fixes #324 #327

closes #325