### PR TITLE
Allow storing deep nested objects to cache

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -7,7 +7,8 @@ import Redis, {
 
 import * as telejson from 'telejson';
 
-const stringify = (value: unknown) => telejson.stringify({ v: value });
+const stringify = (value: unknown) =>
+  telejson.stringify({ v: value }, { maxDepth: Infinity });
 
 const parse = (value: string) => telejson.parse(value)?.v;
 

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -99,6 +99,25 @@ describe('set', () => {
     await redisCache.store.client.disconnect();
     await expect(redisCache.set('foo', 'bar')).rejects.toBeDefined();
   });
+
+  it('should store deep nested objects', async () => {
+    // create a 1000-level deep nested object
+    let deepObj = {};
+    for (let i = 0; i < 999; i++) {
+      deepObj = { foo: deepObj };
+    }
+
+    await redisCache.set('foo', deepObj);
+    await expect(redisCache.get('foo')).resolves.toEqual(deepObj);
+  });
+
+  it('should store cyclic data structure', async () => {
+    const obj: Record<string, unknown> = {};
+    obj['foo'] = obj;
+
+    await redisCache.set('foo', obj);
+    await expect(redisCache.get('foo')).resolves.toEqual(obj);
+  });
 });
 
 describe('mset', () => {


### PR DESCRIPTION
Hey,

Updating to `^2` series of this library caused some issues for us. We eventually tracked it down to `telejson` library limiting depth of serialized objects to 10 by default (replacing deeper leaves silently with a string `"[Object]"`). See https://github.com/storybookjs/telejson/tree/master?tab=readme-ov-file#replacer.

Since this is highly unexpected behaviour for a cache store, in this PR I set the `maxDepth` to `Infinity` (I did not see a way to disable it in any other way) and added a test for that. I'm not sure if there should be a *some* limit, but if so, it should definitely be higher that 10. (1000? Maybe?)

Added a test for storing objects with circular references while at it, since it is something `telejson` enables as well.

Although, I'm not sure whether using `telejson` to allow storing of, for example, arbitrary JS functions and classes to redis is actually a good idea. Perhaps it would be a good idea to limit serialization of those with `telejson` options as well.